### PR TITLE
Switch to cibuildwheel v3.3 for Pyodide wheel builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
           output-dir: ./c-extension/dist
         env:
           CIBW_PLATFORM: pyodide
+          CIBW_BUILD: cp313-pyodide_wasm32
 
       - name: Upload wheel
         uses: actions/upload-artifact@v4
@@ -39,6 +40,7 @@ jobs:
           output-dir: ./rust-extension/dist
         env:
           CIBW_PLATFORM: pyodide
+          CIBW_BUILD: cp313-pyodide_wasm32
 
       - name: Upload wheel
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wasm wheel
-        uses: pypa/cibuildwheel@v2.22
+        uses: pypa/cibuildwheel@v3.3
         with:
           package-dir: ./c-extension
           output-dir: ./c-extension/dist
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wasm wheel
-        uses: pypa/cibuildwheel@v2.22
+        uses: pypa/cibuildwheel@v3.3
         with:
           package-dir: ./rust-extension
           output-dir: ./rust-extension/dist
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install the dependencies
         run: |
           pip install -r requirements-jupyterlite.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,31 +7,19 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
-env:
-  PYTHON_VERSION: "3.11.4"
-  PYODIDE_BUILD_VERSION: "0.24.1"
-  EMSCRIPTEN_VERSION: "3.1.45" # This must be same as $(pyodide config get emscripten_version)
-
 jobs:
   build-c-extension:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install pyodide-build
-        run: |
-          pip install pyodide-build==${{ env.PYODIDE_BUILD_VERSION }}
-
-      - uses: mymindstorm/setup-emsdk@v12
-        with:
-          version: ${{ env.EMSCRIPTEN_VERSION }}
 
       - name: Build wasm wheel
-        run: pyodide build
-        working-directory: ./c-extension
+        uses: pypa/cibuildwheel@v2.22
+        with:
+          package-dir: ./c-extension
+          output-dir: ./c-extension/dist
+        env:
+          CIBW_PLATFORM: pyodide
 
       - name: Upload wheel
         uses: actions/upload-artifact@v4
@@ -40,22 +28,17 @@ jobs:
           path: ./c-extension/dist
 
   build-rust-extension:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - uses: mymindstorm/setup-emsdk@v12
-        with:
-          version: ${{ env.EMSCRIPTEN_VERSION }}
 
       - name: Build wasm wheel
-        run: |
-          pip install maturin
-          maturin build --release -o dist --target wasm32-unknown-emscripten -i python3.11
-        working-directory: ./rust-extension
+        uses: pypa/cibuildwheel@v2.22
+        with:
+          package-dir: ./rust-extension
+          output-dir: ./rust-extension/dist
+        env:
+          CIBW_PLATFORM: pyodide
 
       - name: Upload wheel
         uses: actions/upload-artifact@v4
@@ -98,7 +81,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: "3.12"
       - name: Install the dependencies
         run: |
           pip install -r requirements-jupyterlite.txt

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "pyodide": "^0.24.1"
+    "glob": "^11.0.0",
+    "pyodide": "^0.26.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "glob": "^11.0.0",
-    "pyodide": "^0.26.0"
+    "pyodide": "^0.28.0"
   }
 }

--- a/rust-extension/rust-toolchain.toml
+++ b/rust-extension/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-01-01"
+channel = "nightly-2026-01-01"
 targets = ["wasm32-unknown-emscripten"]

--- a/test_c.js
+++ b/test_c.js
@@ -1,14 +1,16 @@
 const path = require('node:path');
+const { glob } = require('glob');
 const { loadPyodide } = require("pyodide");
 
 async function test_c() {
+    const wheels = await glob('pyodide_wasm_wheel_example-*.whl');
+    if (wheels.length === 0) {
+        throw new Error('No wheel found for pyodide_wasm_wheel_example');
+    }
+    const wheelPath = path.join(__dirname, wheels[0]);
+
     let pyodide = await loadPyodide();
-    await pyodide.loadPackage(
-        path.join(
-            __dirname,
-            '/pyodide_wasm_wheel_example-0.0.0-cp311-cp311-emscripten_3_1_45_wasm32.whl'
-        )
-    );
+    await pyodide.loadPackage(wheelPath);
     return pyodide.runPythonAsync(`
 import pyodide_wasm_wheel_example
 print(pyodide_wasm_wheel_example.f())

--- a/test_rust.js
+++ b/test_rust.js
@@ -1,14 +1,16 @@
 const path = require('node:path');
+const { glob } = require('glob');
 const { loadPyodide } = require("pyodide");
 
 async function test_rust() {
+    const wheels = await glob('rust_extension-*.whl');
+    if (wheels.length === 0) {
+        throw new Error('No wheel found for rust_extension');
+    }
+    const wheelPath = path.join(__dirname, wheels[0]);
+
     let pyodide = await loadPyodide();
-    await pyodide.loadPackage(
-        path.join(
-            __dirname,
-            '/rust_extension-0.1.0-cp311-cp311-emscripten_3_1_45_wasm32.whl'
-        )
-    );
+    await pyodide.loadPackage(wheelPath);
     return pyodide.runPythonAsync(`
 import rust_extension
 print(rust_extension.sum_as_string(1, 2))


### PR DESCRIPTION
## Summary
- Replace pyodide-build and maturin with cibuildwheel v3.3
- Use CIBW_PLATFORM=pyodide for wasm builds
- Build only Python 3.13 / pyodide_2025_0 ABI wheels
- Update npm pyodide to ^0.28.0 for testing
- Update rust-toolchain.toml: nightly-2025-01-01 → nightly-2026-01-01
- Use glob to find wheel files in tests (instead of hardcoded filenames)
- Remove manual Emscripten SDK setup (handled by cibuildwheel)
- Remove version environment variables (managed by cibuildwheel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)