### PR TITLE
Update JupyterLite to 0.7 with Pyodide 0.29

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,19 +77,38 @@ jobs:
 
   jupyterlite:
     runs-on: ubuntu-latest
+    needs:
+      - build-c-extension
+      - build-rust-extension
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download C wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: c-wheel
+          path: ./wheels
+
+      - name: Download Rust wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-wheel
+          path: ./wheels
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+
       - name: Install the dependencies
         run: |
           pip install -r requirements-jupyterlite.txt
+
       - name: Build the JupyterLite site
         run: |
-          jupyter lite build --output-dir dist --contents contents/
+          jupyter lite build --output-dir dist --contents contents/ --piplite-wheels wheels/*.whl
+
       - name: Upload static assets
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           CIBW_PLATFORM: pyodide
           CIBW_BUILD: cp313-pyodide_wasm32
+          CIBW_PYODIDE_VERSION: "0.29.0"
 
       - name: Upload wheel
         uses: actions/upload-artifact@v4
@@ -41,6 +42,7 @@ jobs:
         env:
           CIBW_PLATFORM: pyodide
           CIBW_BUILD: cp313-pyodide_wasm32
+          CIBW_PYODIDE_VERSION: "0.29.0"
 
       - name: Upload wheel
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,9 @@ jobs:
 
       - name: Build the JupyterLite site
         run: |
-          jupyter lite build --output-dir dist --contents contents/ --piplite-wheels wheels/*.whl
+          jupyter lite build --output-dir dist --contents contents/ \
+            --piplite-wheels wheels/pyodide_wasm_wheel_example*.whl \
+            --piplite-wheels wheels/rust_extension*.whl
 
       - name: Upload static assets
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,9 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: List wheels
+        run: ls -la wheels/
+
       - name: Install the dependencies
         run: |
           pip install -r requirements-jupyterlite.txt

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 
 # JupyterLite
 _output/
+jupyterlite/
 .jupyterlite.doit.db
 .ipynb_checkpoints/
 

--- a/contents/README.ipynb
+++ b/contents/README.ipynb
@@ -12,23 +12,7 @@
    "cell_type": "markdown",
    "id": "6614141c-41be-47c9-9788-8a82711d0228",
    "metadata": {},
-   "source": [
-    "WebAssembly-based wheel is deployed in GitHub Pages, and `micropip.install` can install it from URL"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "de13bb33-862c-4f9d-a47b-2c8c388e697f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rust_url = \"https://termoshtt.github.io/pyodide-wasm-wheel-example/rust_extension-0.1.0-cp311-cp311-emscripten_3_1_45_wasm32.whl\"\n",
-    "c_url = \"https://termoshtt.github.io/pyodide-wasm-wheel-example/pyodide_wasm_wheel_example-0.0.0-cp311-cp311-emscripten_3_1_45_wasm32.whl\"\n",
-    "\n",
-    "import micropip\n",
-    "await micropip.install([c_url, rust_url])"
-   ]
+   "source": "The WebAssembly wheels are pre-installed in this JupyterLite environment."
   },
   {
    "cell_type": "markdown",

--- a/contents/README.ipynb
+++ b/contents/README.ipynb
@@ -12,7 +12,15 @@
    "cell_type": "markdown",
    "id": "6614141c-41be-47c9-9788-8a82711d0228",
    "metadata": {},
-   "source": "The WebAssembly wheels are pre-installed in this JupyterLite environment."
+   "source": "The WebAssembly wheels are bundled with this JupyterLite environment and can be installed via piplite."
+  },
+  {
+   "cell_type": "code",
+   "id": "8j9vjmcxulu",
+   "source": "%pip install pyodide_wasm_wheel_example rust_extension",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "glob": "^11.0.0",
-        "pyodide": "^0.28.0"
+        "pyodide": "^0.29.0"
       }
     },
     "node_modules/@isaacs/balanced-match": {
@@ -46,6 +46,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -249,11 +255,12 @@
       }
     },
     "node_modules/pyodide": {
-      "version": "0.28.3",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.28.3.tgz",
-      "integrity": "sha512-rtCsyTU55oNGpLzSVuAd55ZvruJDEX8o6keSdWKN9jPeBVSNlynaKFG7eRqkiIgU7i2M6HEgYtm0atCEQX3u4A==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.29.0.tgz",
+      "integrity": "sha512-ObIvsTmcrxAWKg+FT1GjfSdDmQc5CabnYe/nn5BCuhr9BVVITeQ24DBdZuG5B2tIiAZ9YonBpnDB7cmHZyd2Rw==",
       "license": "MPL-2.0",
       "dependencies": {
+        "@types/emscripten": "^1.41.4",
         "ws": "^8.5.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "glob": "^11.0.0",
-    "pyodide": "^0.28.0"
+    "pyodide": "^0.29.0"
   }
 }

--- a/requirements-jupyterlite.txt
+++ b/requirements-jupyterlite.txt
@@ -1,51 +1,6 @@
-# Copied from https://github.com/jupyterlite/demo/blob/eca1b37903696687a6f084ff8423fe650e85df1d/requirements.txt
+# Core modules
+jupyterlite-core>=0.7.0
+jupyterlab>=4.0
 
-# Core modules (mandatory)
-jupyterlite-core==0.2.2
-jupyterlab~=4.0.9
-notebook~=7.0.6
-
-
-# Python kernel (optional)
-jupyterlite-pyodide-kernel==0.2.0
-
-# JavaScript kernel (optional)
-jupyterlite-javascript-kernel==0.2.2
-
-# Language support (optional)
-jupyterlab-language-pack-fr-FR
-jupyterlab-language-pack-zh-CN
-
-# SQLite kernel (optional)
-jupyterlite-xeus-sqlite==0.2.1
-# P5 kernel (optional)
-jupyterlite-p5-kernel==0.1.0
-# Lua kernel (optional)
-jupyterlite-xeus-lua==0.3.1
-
-# JupyterLab: Fasta file renderer (optional)
-jupyterlab-fasta>=3.3.0,<4
-# JupyterLab: Geojson file renderer (optional)
-jupyterlab-geojson>=3.4.0,<4
-# JupyterLab: guided tour (optional)
-# TODO: re-enable after https://github.com/jupyterlab-contrib/jupyterlab-tour/issues/82
-# jupyterlab-tour
-# JupyterLab: dark theme
-jupyterlab-night
-# JupyterLab: Miami nights theme (optional)
-jupyterlab_miami_nights
-
-# Python: ipywidget library for Jupyter notebooks (optional)
-ipywidgets>=8.1.1,<9
-# Python: ipyevents library for Jupyter notebooks (optional)
-ipyevents>=2.0.1
-# Python: interative Matplotlib library for Jupyter notebooks (optional)
-ipympl>=0.8.2
-# Python: ipycanvas library for Jupyter notebooks (optional)
-ipycanvas>=0.9.1
-# Python: ipyleaflet library for Jupyter notebooks (optional)
-ipyleaflet
-
-# Python: plotting libraries (optional)
-plotly>=5,<6
-bqplot
+# Python kernel (Pyodide)
+jupyterlite-pyodide-kernel>=0.7.0


### PR DESCRIPTION
## Summary

Update JupyterLite and Pyodide ecosystem to latest versions for compatibility.

### Version Updates
- jupyterlite-core >= 0.7.0
- jupyterlite-pyodide-kernel >= 0.7.0 (uses Pyodide 0.29)
- cibuildwheel: `CIBW_PYODIDE_VERSION: "0.29.0"`
- npm pyodide: ^0.29.0

### JupyterLite Changes
- Simplify requirements-jupyterlite.txt to essential packages only
- Bundle wheels using `--piplite-wheels` (specified twice for both C and Rust wheels)
- Use `%pip install` magic in README.ipynb to install bundled wheels
- Use `npm ci` instead of `npm install` in CI

### Other Changes
- Add debug step to list wheels before JupyterLite build
- Add `jupyterlite/` to .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)