### PR TITLE
Add C++ extension example and unify package naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,15 +50,37 @@ jobs:
           name: rust-wheel
           path: ./rust-extension/dist
 
+  build-cpp-extension:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wasm wheel
+        uses: pypa/cibuildwheel@v3.3
+        with:
+          package-dir: ./cpp-extension
+          output-dir: ./cpp-extension/dist
+        env:
+          CIBW_PLATFORM: pyodide
+          CIBW_BUILD: cp313-pyodide_wasm32
+          CIBW_PYODIDE_VERSION: "0.29.0"
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpp-wheel
+          path: ./cpp-extension/dist
+
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target: [rust, c]
+        target: [rust, c, cpp]
     needs:
       - build-rust-extension
       - build-c-extension
+      - build-cpp-extension
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -82,6 +104,7 @@ jobs:
     needs:
       - build-c-extension
       - build-rust-extension
+      - build-cpp-extension
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -98,6 +121,12 @@ jobs:
           name: rust-wheel
           path: ./wheels
 
+      - name: Download C++ wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: cpp-wheel
+          path: ./wheels
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
@@ -112,7 +141,8 @@ jobs:
         run: |
           uv run --project jupyterlite jupyter lite build --output-dir dist --contents jupyterlite/contents/ \
             --piplite-wheels wheels/pyodide_wasm_wheel_example*.whl \
-            --piplite-wheels wheels/rust_extension*.whl
+            --piplite-wheels wheels/rust_extension*.whl \
+            --piplite-wheels wheels/cpp_extension*.whl
 
       - name: Upload static assets
         uses: actions/upload-artifact@v4
@@ -124,6 +154,7 @@ jobs:
     needs:
       - build-c-extension
       - build-rust-extension
+      - build-cpp-extension
       - jupyterlite
 
     if: github.ref == 'refs/heads/main'
@@ -147,6 +178,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: c-wheel
+          path: "."
+
+      - name: Download C++ wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: cpp-wheel
           path: "."
 
       - name: Download JupyterLite

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Build the JupyterLite site
         run: |
           uv run --project jupyterlite jupyter lite build --output-dir dist --contents jupyterlite/contents/ \
-            --piplite-wheels wheels/pyodide_wasm_wheel_example*.whl \
+            --piplite-wheels wheels/c_extension*.whl \
             --piplite-wheels wheels/rust_extension*.whl \
             --piplite-wheels wheels/cpp_extension*.whl
 

--- a/c-extension/lib.c
+++ b/c-extension/lib.c
@@ -14,13 +14,13 @@ static PyMethodDef methods[] = {
 
 static struct PyModuleDef mod = {
     PyModuleDef_HEAD_INIT,
-    "pyodide_wasm_wheel_example",
+    "c_extension",
     NULL,
     -1,
     methods};
 
 PyMODINIT_FUNC
-PyInit_pyodide_wasm_wheel_example(void)
+PyInit_c_extension(void)
 {
     return PyModule_Create(&mod);
 }

--- a/c-extension/pyproject.toml
+++ b/c-extension/pyproject.toml
@@ -1,11 +1,12 @@
-[project]
-name = "pyodide-wasm-wheel-example"
-description = "Example for Wasm wheel for Pyodide"
-readme = "README.md"
-license = { file = "LICENSE" }
-classifiers = [ "Programming Language :: Python :: 3", ]
-dynamic = ["version"]
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "c-extension"
+version = "0.1.0"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: C",
+    "Programming Language :: Python :: Implementation :: CPython",
+]

--- a/c-extension/setup.py
+++ b/c-extension/setup.py
@@ -3,7 +3,7 @@ from setuptools import Extension, setup
 setup(
     ext_modules=[
         Extension(
-            name="pyodide_wasm_wheel_example",
+            name="c_extension",
             sources=["lib.c"],
         ),
     ]

--- a/cpp-extension/CMakeLists.txt
+++ b/cpp-extension/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(cpp_extension LANGUAGES CXX)
 
+# Use FindPython instead of deprecated FindPythonLibs for cross-compilation support
+set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 pybind11_add_module(cpp_extension src/main.cpp)

--- a/cpp-extension/CMakeLists.txt
+++ b/cpp-extension/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(cpp_extension LANGUAGES CXX)
+
+find_package(pybind11 CONFIG REQUIRED)
+
+pybind11_add_module(cpp_extension src/main.cpp)
+
+install(TARGETS cpp_extension DESTINATION .)

--- a/cpp-extension/pyproject.toml
+++ b/cpp-extension/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["scikit-build-core>=0.10", "pybind11"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "cpp-extension"
+version = "0.1.0"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: C++",
+    "Programming Language :: Python :: Implementation :: CPython",
+]
+
+[tool.scikit-build]
+wheel.expand-macos-universal-tags = true

--- a/cpp-extension/src/main.cpp
+++ b/cpp-extension/src/main.cpp
@@ -1,0 +1,14 @@
+#include <pybind11/pybind11.h>
+#include <string>
+
+namespace py = pybind11;
+
+std::string sum_as_string(int a, int b) {
+    return std::to_string(a + b);
+}
+
+PYBIND11_MODULE(cpp_extension, m) {
+    m.doc() = "A Python module implemented in C++";
+    m.def("sum_as_string", &sum_as_string, "Formats the sum of two numbers as string",
+          py::arg("a"), py::arg("b"));
+}

--- a/jupyterlite/contents/README.ipynb
+++ b/jupyterlite/contents/README.ipynb
@@ -17,7 +17,7 @@
   {
    "cell_type": "code",
    "id": "8j9vjmcxulu",
-   "source": "%pip install pyodide_wasm_wheel_example rust_extension",
+   "source": "%pip install pyodide_wasm_wheel_example rust_extension cpp_extension",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -59,6 +59,20 @@
     "import rust_extension\n",
     "rust_extension.sum_as_string(1, 2)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "zmreoj0lohb",
+   "source": "## C++ extension test",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "t4jmakiz5d",
+   "source": "import cpp_extension\ncpp_extension.sum_as_string(1, 2)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/jupyterlite/contents/README.ipynb
+++ b/jupyterlite/contents/README.ipynb
@@ -17,7 +17,7 @@
   {
    "cell_type": "code",
    "id": "8j9vjmcxulu",
-   "source": "%pip install pyodide_wasm_wheel_example rust_extension cpp_extension",
+   "source": "%pip install c_extension rust_extension cpp_extension",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -36,10 +36,7 @@
    "id": "0c277e52-fcb1-49e4-83e3-92927cb06211",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import pyodide_wasm_wheel_example\n",
-    "pyodide_wasm_wheel_example.f()"
-   ]
+   "source": "import c_extension\nc_extension.f()"
   },
   {
    "cell_type": "markdown",

--- a/tests/test_c.js
+++ b/tests/test_c.js
@@ -3,17 +3,17 @@ const { glob } = require('glob');
 const { loadPyodide } = require("pyodide");
 
 async function test_c() {
-    const wheels = await glob('../pyodide_wasm_wheel_example-*.whl', { cwd: __dirname });
+    const wheels = await glob('../c_extension-*.whl', { cwd: __dirname });
     if (wheels.length === 0) {
-        throw new Error('No wheel found for pyodide_wasm_wheel_example');
+        throw new Error('No wheel found for c_extension');
     }
     const wheelPath = path.resolve(__dirname, wheels[0]);
 
     let pyodide = await loadPyodide();
     await pyodide.loadPackage(wheelPath);
     return pyodide.runPythonAsync(`
-import pyodide_wasm_wheel_example
-print(pyodide_wasm_wheel_example.f())
+import c_extension
+print(c_extension.f())
     `);
 }
 

--- a/tests/test_cpp.js
+++ b/tests/test_cpp.js
@@ -1,0 +1,20 @@
+const path = require('node:path');
+const { glob } = require('glob');
+const { loadPyodide } = require("pyodide");
+
+async function test_cpp() {
+    const wheels = await glob('../cpp_extension-*.whl', { cwd: __dirname });
+    if (wheels.length === 0) {
+        throw new Error('No wheel found for cpp_extension');
+    }
+    const wheelPath = path.resolve(__dirname, wheels[0]);
+
+    let pyodide = await loadPyodide();
+    await pyodide.loadPackage(wheelPath);
+    return pyodide.runPythonAsync(`
+import cpp_extension
+print(cpp_extension.sum_as_string(1, 2))
+    `);
+}
+
+test_cpp();


### PR DESCRIPTION
## Summary

- Add `cpp-extension/` directory with pybind11 + scikit-build-core example
- Rename c-extension package from `pyodide-wasm-wheel-example` to `c-extension` for consistency

## Structure

All extensions now follow the same naming convention:

| Directory | Package Name | Module Name |
|-----------|--------------|-------------|
| `c-extension/` | `c-extension` | `c_extension` |
| `rust-extension/` | `rust-extension` | `rust_extension` |
| `cpp-extension/` | `cpp-extension` | `cpp_extension` |

## cpp-extension

```
cpp-extension/
├── pyproject.toml    # scikit-build-core configuration
├── CMakeLists.txt    # CMake build configuration
└── src/
    └── main.cpp      # pybind11 module
```

## Changes

- Add cpp-extension build job to CI workflow
- Add test for cpp-extension
- Include cpp_extension in JupyterLite
- Use `PYBIND11_FINDPYTHON` for cross-compilation support

🤖 Generated with [Claude Code](https://claude.com/claude-code)